### PR TITLE
Fixed an apparent bug where the twist was not set properly with segmented quadratures.

### DIFF
--- a/src/interfaces/components/beam.cpp
+++ b/src/interfaces/components/beam.cpp
@@ -301,7 +301,7 @@ std::vector<BeamSection> Beam::BuildBeamSections_SegmentedGLL(const BeamInput& i
 
             // Calculate twist at current section location via linear interpolation
             const auto twist = math::LinearInterp(
-                section_location, input.ref_axis.twist_grid, input.ref_axis.twist
+                grid_value, input.ref_axis.twist_grid, input.ref_axis.twist
             );
 
             // Add refinement section
@@ -370,7 +370,7 @@ std::vector<BeamSection> Beam::BuildBeamSections_SegmentedGL(const BeamInput& in
 
             // Calculate twist at current section location via linear interpolation
             const auto twist = math::LinearInterp(
-                section_location, input.ref_axis.twist_grid, input.ref_axis.twist
+                grid_value, input.ref_axis.twist_grid, input.ref_axis.twist
             );
 
             // Add refinement section


### PR DESCRIPTION


Because none of our tests exerceise changing twist and anything other than trapezoidal rule quadrature, this was undetected previously.